### PR TITLE
VLN-538: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - "releases/*"
+permissions:
+  contents: read
 
 jobs:
   build-lint-test:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a workflow-level permissions block restricting the GITHUB_TOKEN to read-only repository contents, which is sufficient for checkout and build steps.